### PR TITLE
Add readable plugins & load them into adminer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,8 @@ FROM adminer:latest
 
 COPY ./html /var/www/html/
 
+COPY --chown=adminer:adminer /plugins /var/www/html/plugins
+COPY --chown=adminer:adminer /plugins-enabled /var/www/html/plugins-enabled
+
 ENV LOGIN_SERVERS = '{}'
 ENV PHP_CLI_SERVER_WORKERS = 5

--- a/plugins-enabled/readable-binaries.php
+++ b/plugins-enabled/readable-binaries.php
@@ -1,0 +1,5 @@
+<?php
+
+require_once (__DIR__ . '/../plugins/readable-binaries.php');
+
+return new AdminerReadableBinaries();

--- a/plugins-enabled/readable-dates.php
+++ b/plugins-enabled/readable-dates.php
@@ -1,0 +1,5 @@
+<?php
+
+require_once (__DIR__ . '/../plugins/readable-dates.php');
+
+return new AdminerReadableDates();

--- a/plugins-enabled/searchable-binaries.php
+++ b/plugins-enabled/searchable-binaries.php
@@ -1,0 +1,5 @@
+<?php
+
+require_once (__DIR__ . '/../plugins/searchable-binaries.php');
+
+return new AdminerSearchableBinaries();

--- a/plugins/readable-binaries.php
+++ b/plugins/readable-binaries.php
@@ -1,0 +1,98 @@
+<?php
+
+/** This plugin replaces UNIX timestamps with human-readable dates in your local format.
+ * Mouse click on the date field reveals timestamp back.
+ *
+ * @link https://www.adminer.org/plugins/#use
+ * @author Anonymous
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @license http://www.gnu.org/licenses/gpl-2.0.html GNU General Public License, version 2 (one or other)
+ */
+class AdminerReadableBinaries {
+    /** @access protected */
+    var $prepend;
+
+    function __construct() {
+        $this->prepend = <<<EOT
+function hexToBase32(hex) {
+    const base32Chars = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+    let value = BigInt('0x' + hex); // Convert the hex string to BigInt
+    let ulid = '';
+
+    // Continuously divide the value by 32 and get the remainders
+    while (value > 0) {
+        const remainder = value % BigInt(32);
+        ulid = base32Chars[Number(remainder)] + ulid;
+        value = value / BigInt(32);
+    }
+
+    // Pad the result to 26 characters, as ULID should always be 26 chars long
+    return ulid.padStart(26, '0');
+}
+function hexToUuid(hex) {
+    // Correctly map the hexadecimal to UUID format
+    const rearranged = hex.slice(8, 16) +
+                       '-' + hex.slice(4, 8) +
+                       '-' + hex.slice(0, 4) +
+                       '-' + hex.slice(16, 20) +
+                       '-' + hex.slice(20);
+
+    // Return the lowercased UUID string
+    return rearranged.toLowerCase();
+}
+
+function createElementFromHTML(htmlString) {
+  var div = document.createElement('div');
+  div.innerHTML = htmlString.trim();
+
+  // Change this to div.childNodes to support multiple top-level nodes.
+  return div.firstChild;
+}
+
+document.addEventListener('DOMContentLoaded', function(event) {
+    var nextType = {'ulid': 'uuid', 'uuid': 'raw', 'raw': 'ulid'};
+    var tds = document.querySelectorAll('td[id^="val"]');
+    for (var i = 0; i < tds.length; i++) {
+        var text = tds[i].innerText.trim();
+        if (text.match(/^[0-9A-F]{32}$/)) {
+            var flexContainer = document.createElement('div');
+            flexContainer.style.display = 'flex';
+            flexContainer.style['justify-content'] = 'space-between';
+
+            flexContainer.raw = '<code title="Raw">' + text + '</code>';
+            flexContainer.ulid = '<code title="ULID">' + hexToBase32(text) + '</code>';
+            flexContainer.uuid = '<code title="UUID">' + hexToUuid(text) + '</code>';
+            
+            var child = tds[i].childNodes[0];
+            flexContainer.appendChild(child);
+            tds[i].appendChild(flexContainer);
+            var node = flexContainer.childNodes[0].nodeName == 'A' ? flexContainer.childNodes[0] : flexContainer;
+            node.innerHTML = flexContainer.ulid;
+            flexContainer.type = 'ulid';
+            
+            var switchButton = document.createElement('span');
+            switchButton.innerText = ' 🔄  ';
+            switchButton.style.cursor = 'pointer';
+            flexContainer.prepend(switchButton);
+
+            flexContainer.childNodes[0].addEventListener('click', function(event) {
+                this.parentElement.type = nextType[this.parentElement.type];
+                if (this.parentElement.childNodes[1].nodeName == 'A') {
+                    var node = this.parentElement.childNodes[1];
+                    node.replaceChild(createElementFromHTML(this.parentElement[this.parentElement.type]), node.childNodes[0]);
+                } else {
+                    var node = this.parentElement;
+                    node.replaceChild(createElementFromHTML(this.parentElement[this.parentElement.type]), node.childNodes[1]);
+                }
+            });
+        }
+    }
+});
+
+EOT;
+    }
+
+    function head() {
+        echo script($this->prepend);
+    }
+}

--- a/plugins/readable-dates.php
+++ b/plugins/readable-dates.php
@@ -1,0 +1,49 @@
+<?php
+
+/** This plugin replaces UNIX timestamps with human-readable dates in your local format.
+ * Mouse click on the date field reveals timestamp back.
+ *
+ * @link https://www.adminer.org/plugins/#use
+ * @author Anonymous
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @license http://www.gnu.org/licenses/gpl-2.0.html GNU General Public License, version 2 (one or other)
+ */
+class AdminerReadableDates {
+    /** @access protected */
+    var $prepend;
+
+    function __construct() {
+        $this->prepend = <<<EOT
+
+document.addEventListener('DOMContentLoaded', function(event) {
+    var date = new Date();
+    var tds = document.querySelectorAll('td[id^="val"]');
+    for (var i = 0; i < tds.length; i++) {
+        var text = tds[i].innerHTML.trim();
+        if (text.match(/^\d{10}$/)) {
+            date.setTime(parseInt(text) * 1000);
+            tds[i].oldDate = text;
+
+            // tds[i].newDate = date.toUTCString().substr(5); // UTC format
+            tds[i].newDate = date.toLocaleString();    // Local format
+            // tds[i].newDate = date.toLocaleFormat('%e %b %Y %H:%M:%S'); // Custom format - works in Firefox only
+
+            tds[i].newDate = '<span style="color: #009900">' + tds[i].newDate + '</span>';
+            tds[i].innerHTML = tds[i].newDate;
+            tds[i].dateIsNew = true;
+
+            tds[i].addEventListener('click', function(event) {
+                this.innerHTML = (this.dateIsNew ? this.oldDate : this.newDate);
+                this.dateIsNew = !this.dateIsNew;
+            });
+        }
+    }
+});
+
+EOT;
+    }
+
+    function head() {
+        echo script($this->prepend);
+    }
+}

--- a/plugins/searchable-binaries.php
+++ b/plugins/searchable-binaries.php
@@ -1,0 +1,70 @@
+<?php
+
+/** This plugin replaces UNIX timestamps with human-readable dates in your local format.
+ * Mouse click on the date field reveals timestamp back.
+ *
+ * @link https://www.adminer.org/plugins/#use
+ * @author Anonymous
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @license http://www.gnu.org/licenses/gpl-2.0.html GNU General Public License, version 2 (one or other)
+ */
+class AdminerSearchableBinaries {
+    /** @access protected */
+    var $prepend;
+
+    function __construct() {
+        $this->prepend = <<<EOT
+function base32ToHex(ulid) {
+    const base32Chars = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+    let value = BigInt(0);
+    
+    // Decode each Base32 character to its corresponding BigInt value
+    for (const char of ulid) {
+        const idx = base32Chars.indexOf(char.toUpperCase());
+        if (idx === -1) {
+            throw new Error('Invalid character in ULID: ' + char);
+        }
+        value = (value * BigInt(32)) + BigInt(idx);
+    }
+    
+    // Convert the BigInt value to a hexadecimal string, padded to 32 characters
+    let hex = value.toString(16).toUpperCase().padStart(32, '0');
+    
+    return hex;
+}
+
+function uuidToHex(uuid) {
+    // Remove dashes from the UUID
+    const noDashes = uuid.replace(/-/g, '');
+
+    // Rearrange the sections of the UUID into the required order
+    const rearranged = noDashes.slice(12, 16) +  // Characters 12-15
+                       noDashes.slice(8, 12) +   // Characters 8-11
+                       noDashes.slice(0, 8) +    // Characters 0-7
+                       noDashes.slice(16);       // Characters 16 onwards
+
+    // Return the uppercased hex value
+    return rearranged.toUpperCase();
+}
+
+document.addEventListener('DOMContentLoaded', function(event) {
+	var inputs = document.querySelectorAll('div#fieldset-search > div > input');
+	for (var i = 0; i < inputs.length; i++) {
+		inputs[i].addEventListener('change', function(event) {
+		    if (event.target.value.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)) {
+		        event.target.value = uuidToHex(event.target.value);
+		    }
+		    if (event.target.value.match(/^[0-9A-HJ-KMNP-TV-Z]{26}$/)) {
+		        event.target.value = base32ToHex(event.target.value);
+		    }
+		})
+	}
+});
+
+EOT;
+    }
+
+    function head() {
+        echo script($this->prepend);
+    }
+}


### PR DESCRIPTION
Adding plugins for better readability:
- `readable-dates` tries to detect timestamps & displays them in a human-readable format;
- `readable-binaries` tries to detect binary HEX representations and displays them in ULID/UUID format;
- `searchable-binaries` tries to detect ULID/UUID filled in search inputs and converts them to their binary representations.