### PR TITLE
Add a basic auth protection to prevent public access from the Internet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,25 @@ COPY ./html /var/www/html/
 COPY --chown=adminer:adminer /plugins /var/www/html/plugins
 COPY --chown=adminer:adminer /plugins-enabled /var/www/html/plugins-enabled
 
-ENV LOGIN_SERVERS = '{}'
-ENV PHP_CLI_SERVER_WORKERS = 5
+ENV LOGIN_SERVERS='{}'
+ENV PHP_CLI_SERVER_WORKERS=5
+
+ENV PROTECTED_ACCESS=''
+
+RUN echo "AuthType Basic" > /var/www/html/.htaccess && \
+    echo "AuthName \"Restricted Access\"" >> /var/www/html/.htaccess && \
+    echo "AuthUserFile /var/www/html/.htpasswd" >> /var/www/html/.htaccess && \
+    echo "Require valid-user" >> /var/www/html/.htaccess && \
+    touch /var/www/html/.htpasswd && \
+    echo "$PROTECTED_ACCESS" >> /var/www/html/.htpasswd
+
+# Install Nginx
+USER root
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+
+# Configure Nginx as a reverse proxy for Adminer
+RUN rm /etc/nginx/sites-enabled/default
+COPY etc/nginx/adminer.conf /etc/nginx/conf.d/adminer.conf
+
+# Replace Admin default CMD by starting Nginx and Adminer with another port
+CMD service nginx start && php -S 127.0.0.1:8880 -t /var/www/html/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@
 
 This image based on the official [Adminer Docker image](https://hub.docker.com/_/adminer) ships the required setup to connect with SSL to an Azure MySQL Single or Flexible Server.
 
+It uses Nginx as a proxy server to first check Basic Auth before forwarding to Adminer PHP built-in server.
+
 A daily build is available on the [Docker Hub](https://hub.docker.com/r/assoconnect/adminer-azure).
+
+## Basic authentification to protect from any public access
+
+Define the env variable `PROTECTED_ACCESS` with the given result of the htpasswd tool (i.e. `user:password`)
 
 ## Login SSL
 This image ships with the required setup to connect with SSL to an Azure MySQL Single or Flexible Server.) ships the required setup to connect with SSL to an Azure MySQL Single or Flexible Server

--- a/etc/nginx/adminer.conf
+++ b/etc/nginx/adminer.conf
@@ -1,0 +1,19 @@
+server {
+    listen 8080;
+
+    # Access rules (Basic authentication equivalent to .htaccess)
+    location / {
+        auth_basic "Restricted Access";
+        auth_basic_user_file /var/www/html/.htpasswd;
+
+        proxy_pass http://127.0.0.1:8880; # Forwarding request to built-in PHP server
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    # Deny access to .ht* files
+    location ~ /\.ht {
+        deny all;
+    }
+}


### PR DESCRIPTION
Adminer is using the built-in PHP server on the 8080 port.

Install an nginx server to check the valid authentifation and forward the request to the built-in PHP server.
Use an environment variable to setup the user:password access.