### PR TITLE
Fix integration of nginx & adminer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adminer:latest
+FROM adminer:4.8.1
 
 COPY ./html /var/www/html/
 
@@ -25,5 +25,12 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN rm /etc/nginx/sites-enabled/default
 COPY etc/nginx/adminer.conf /etc/nginx/conf.d/adminer.conf
 
-# Replace Admin default CMD by starting Nginx and Adminer with another port
-CMD service nginx start && php -S 127.0.0.1:8880 -t /var/www/html/
+# Expose ports used by Nginx and Adminer
+EXPOSE 80 8880
+
+# Use a script to start both Nginx and PHP-Adminer in parallel
+COPY start.sh /start.sh
+RUN chmod +x /start.sh
+
+# Start Nginx and Adminer
+CMD ["/start.sh"]

--- a/etc/nginx/adminer.conf
+++ b/etc/nginx/adminer.conf
@@ -1,5 +1,7 @@
 server {
-    listen 8080;
+    listen 80;
+
+    access_log off;
 
     # Access rules (Basic authentication equivalent to .htaccess)
     location / {

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Start Nginx in the background
+nginx &
+
+# Start Adminer on a custom port
+php -S 127.0.0.1:8880 -t /var/www/html/


### PR DESCRIPTION
- Set the Adminer version to keep usage of apt-get Adminer major version now uses apk
Plugin integrations has breaking changes, to be fix later.
- Add a start.sh + CMD instruction in Docker to remove a warning
- Fix port used by Nginx and remove access logs to prevent filling the hdd